### PR TITLE
feat: daily sales report endpoint and data snapshotting

### DIFF
--- a/bruno/kasir-api/GET DailyReport.bru
+++ b/bruno/kasir-api/GET DailyReport.bru
@@ -1,0 +1,15 @@
+meta {
+  name: GET DailyReport
+  type: http
+  seq: 14
+}
+
+get {
+  url: {{base_url}}/api/report/hari-ini
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+}

--- a/handlers/report_handler.go
+++ b/handlers/report_handler.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"encoding/json"
+	"kasir-api/models"
+	"kasir-api/services"
+	"net/http"
+)
+
+type ReportHandler struct {
+	service *services.ReportService
+}
+
+func NewReportHandler(service *services.ReportService) *ReportHandler {
+	return &ReportHandler{service: service}
+}
+
+func (h *ReportHandler) HandleReport(w http.ResponseWriter, r *http.Request) {
+
+	switch r.Method {
+	case http.MethodGet:
+		h.GetDailyReport(w, r)
+
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+
+	}
+}
+
+func (h *ReportHandler) GetDailyReport(w http.ResponseWriter, r *http.Request) {
+	dailyReport, err := h.service.GetDailyReport()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	h.sendResponse(w, http.StatusOK, "Successfully retrieved daily report", dailyReport)
+}
+
+func (h *ReportHandler) sendResponse(w http.ResponseWriter, status int, message string, data any) {
+	response := models.Response{
+		Message: message,
+		Data:    data,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(response)
+}

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 	productRepo := repositories.NewProductRepository(db)
 	categoryRepo := repositories.NewCategoryRepository(db)
 	transactionRepo := repositories.NewTransactionRepository(db)
+	reportRepo := repositories.NewReportRepository(db)
 
 	categoryService := services.NewCategoryService(categoryRepo)
 	categoryHandler := handlers.NewCategoryHandler(categoryService)
@@ -55,6 +56,9 @@ func main() {
 	transactionService := services.NewTransactionService(transactionRepo)
 	transactionHandler := handlers.NewTransactionHandler(transactionService)
 
+	reportService := services.NewReportService(reportRepo)
+	reportHandler := handlers.NewReportHandler(reportService)
+
 	// setup routes
 	http.HandleFunc("/api/product", productHandler.HandleProducts)
 	http.HandleFunc("/api/product/", productHandler.HandleProductByID)
@@ -63,6 +67,8 @@ func main() {
 	http.HandleFunc("/api/categories/", categoryHandler.HandleCategoryByID)
 
 	http.HandleFunc("/api/checkout", transactionHandler.HandleCheckout)
+
+	http.HandleFunc("/api/report/hari-ini", reportHandler.HandleReport)
 
 	// localhost:8080/health
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/models/report.go
+++ b/models/report.go
@@ -1,0 +1,12 @@
+package models
+
+type BestSellerItem struct {
+	ProductName  string `json:"product_name"`
+	QuantitySold int    `json:"quantity_sold"`
+}
+
+type DailyReport struct {
+	TotalRevenue int            `json:"total_revenue"`
+	TotalSales   int            `json:"total_sales"`
+	BestSellers  BestSellerItem `json:"best_sellers"`
+}

--- a/repositories/report_repository.go
+++ b/repositories/report_repository.go
@@ -1,0 +1,58 @@
+package repositories
+
+import (
+	"database/sql"
+	"kasir-api/models"
+)
+
+type ReportRepository struct {
+	db *sql.DB
+}
+
+func NewReportRepository(db *sql.DB) *ReportRepository {
+	return &ReportRepository{db: db}
+}
+
+func (repo *ReportRepository) GetDailyReport() (*models.DailyReport, error) {
+	var r models.DailyReport
+	query := `
+WITH stats AS (
+    SELECT 
+        COALESCE(SUM(total_amount), 0) AS total_revenue,
+        COUNT(id) AS total_sales
+    FROM transactions
+    WHERE created_at::date = CURRENT_DATE
+),
+top_product AS (
+    SELECT 
+        product_name,
+        SUM(quantity) AS quantity_sold
+    FROM transaction_details td
+    JOIN transactions t ON td.transaction_id = t.id
+    WHERE t.created_at::date = CURRENT_DATE
+    GROUP BY product_name
+    ORDER BY quantity_sold DESC, SUM(subtotal) DESC
+    LIMIT 1
+)
+SELECT 
+    s.total_revenue, 
+    s.total_sales,
+    COALESCE(tp.product_name, 'No Sales') AS product_name,
+    COALESCE(tp.quantity_sold, 0) AS quantity_sold
+FROM stats s
+LEFT JOIN top_product tp ON true;
+	`
+
+	err := repo.db.QueryRow(query).Scan(
+		&r.TotalRevenue,
+		&r.TotalSales,
+		&r.BestSellers.ProductName,
+		&r.BestSellers.QuantitySold,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}

--- a/repositories/transaction_repository.go
+++ b/repositories/transaction_repository.go
@@ -79,7 +79,7 @@ func (repo *TransactionRepository) CreateTransaction(items []models.CheckoutItem
 	// insert transactionDetails
 	for i := range details {
 		details[i].TransactionID = transactionID
-		err = tx.QueryRow("INSERT INTO transaction_details (transaction_id, product_id, price, quantity, subtotal) VALUES ($1, $2, $3, $4, $5) RETURNING id", transactionID, details[i].ProductID, details[i].Price, details[i].Quantity, details[i].Subtotal).Scan(&details[i].ID)
+		err = tx.QueryRow("INSERT INTO transaction_details (transaction_id, product_id, product_name, price, quantity, subtotal) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id", transactionID, details[i].ProductID, details[i].ProductName, details[i].Price, details[i].Quantity, details[i].Subtotal).Scan(&details[i].ID)
 		if err != nil {
 			return nil, err
 		}

--- a/services/report_service.go
+++ b/services/report_service.go
@@ -1,0 +1,18 @@
+package services
+
+import (
+	"kasir-api/models"
+	"kasir-api/repositories"
+)
+
+type ReportService struct {
+	repo *repositories.ReportRepository
+}
+
+func NewReportService(repo *repositories.ReportRepository) *ReportService {
+	return &ReportService{repo: repo}
+}
+
+func (s *ReportService) GetDailyReport() (*models.DailyReport, error) {
+	return s.repo.GetDailyReport()
+}


### PR DESCRIPTION
This PR introduces the daily sales report feature (`GET /api/report/hari-ini`). It includes database schema improvements to ensure historical data integrity and an optimized query for sales aggregation.

### Changes
- **Data Integrity**: Added `product_name` snapshotting in `transaction_details` to prevent report changes if master product data is updated.
- **Optimized Query**: Implemented a Single-Query Report using **PostgreSQL CTE** to fetch total revenue, total sales, and best-selling products in one trip.
- **Tie-Breaker Logic**: Best-seller selection now prioritizes higher revenue (subtotal) if sales quantities are equal.
- **Clean Architecture**: Added new layers for Report (Handler, Service, Repository) and wired them in `main.go`.
- **API Testing**: Added Bruno collection file for easy endpoint verification.

Closes #7 