### PR TITLE
feat: add GET /api/report with date range and Bruno collection

### DIFF
--- a/bruno/kasir-api/GET ReportWithDate.bru
+++ b/bruno/kasir-api/GET ReportWithDate.bru
@@ -1,0 +1,21 @@
+meta {
+  name: GET ReportWithDate
+  type: http
+  seq: 15
+}
+
+get {
+  url: {{base_url}}/api/report?start_date=2026-02-01&end_date=2026-02-06
+  body: none
+  auth: inherit
+}
+
+params:query {
+  start_date: 2026-02-01
+  end_date: 2026-02-06
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/handlers/report_handler.go
+++ b/handlers/report_handler.go
@@ -45,6 +45,29 @@ func (h *ReportHandler) GetDailyReport(w http.ResponseWriter, r *http.Request) {
 	h.sendResponse(w, http.StatusOK, message, dailyReport)
 }
 
+func (h *ReportHandler) GetReport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		h.sendResponse(w, http.StatusMethodNotAllowed, "Method not allowed", nil)
+		return
+	}
+	startDate := r.URL.Query().Get("start_date")
+	endDate := r.URL.Query().Get("end_date")
+	report, err := h.service.GetReport(startDate, endDate)
+	if err != nil {
+		log.Printf("Failed to get report: %v", err)
+
+		h.sendResponse(w, http.StatusInternalServerError, "Internal server error", nil)
+		return
+	}
+	message := "Successfully retrieved report with start_date and end_date"
+	if startDate == "" || endDate == "" {
+		message = "Successfully retrieved report"
+	}
+
+	h.sendResponse(w, http.StatusOK, message, report)
+
+}
+
 func (h *ReportHandler) sendResponse(w http.ResponseWriter, status int, message string, data any) {
 	response := models.Response{
 		Message: message,

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 	http.HandleFunc("/api/checkout", transactionHandler.HandleCheckout)
 
 	http.HandleFunc("/api/report/hari-ini", reportHandler.HandleReport)
+	http.HandleFunc("/api/report", reportHandler.GetReport)
 
 	// localhost:8080/health
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/models/report.go
+++ b/models/report.go
@@ -10,3 +10,26 @@ type DailyReport struct {
 	TotalSales   int            `json:"total_sales"`
 	BestSellers  BestSellerItem `json:"best_sellers"`
 }
+
+type ProductStat struct {
+	ProductName string `json:"product_name"`
+	Quantity    int    `json:"quantity"`
+}
+
+type TrendStat struct {
+	Date         string `json:"date"`
+	TotalRevenue int    `json:"daily_revenue"`
+}
+
+type ReportSummary struct {
+	TotalRevenue      float64 `json:"total_revenue"`
+	TotalTransactions int     `json:"total_transactions"`
+	AOV               float64 `json:"avg_order_value"`
+	TotalItemsSold    int     `json:"total_items_sold"`
+}
+
+type FullReport struct {
+	Summary           ReportSummary `json:"summary"`
+	Top5Products      []ProductStat `json:"top_5_products"`
+	DailyRevenueTrend []TrendStat   `json:"daily_revenue_trend"`
+}

--- a/repositories/report_repository.go
+++ b/repositories/report_repository.go
@@ -2,7 +2,9 @@ package repositories
 
 import (
 	"database/sql"
+	"encoding/json"
 	"kasir-api/models"
+	"time"
 )
 
 type ReportRepository struct {
@@ -14,7 +16,7 @@ func NewReportRepository(db *sql.DB) *ReportRepository {
 }
 
 func (repo *ReportRepository) GetDailyReport() (*models.DailyReport, error) {
-	var r models.DailyReport
+
 	query := `
 WITH stats AS (
     SELECT 
@@ -44,7 +46,7 @@ SELECT
 FROM stats s
 LEFT JOIN top_product tp ON true;
 	`
-
+	var r models.DailyReport
 	err := repo.db.QueryRow(query).Scan(
 		&r.TotalRevenue,
 		&r.TotalSales,
@@ -56,5 +58,90 @@ LEFT JOIN top_product tp ON true;
 		return nil, err
 	}
 
+	return &r, nil
+}
+
+func (repo *ReportRepository) GetReport(startDate, endDate string) (*models.FullReport, error) {
+	now := time.Now()
+	if startDate == "" {
+		startDate = now.AddDate(0, 0, -30).Format("2006-01-02")
+	}
+	if endDate == "" {
+		endDate = now.Format("2006-01-02")
+	}
+
+	query := `
+WITH date_range AS (
+    SELECT 
+        ($1::date AT TIME ZONE 'Asia/Jakarta') AS start_ts,
+        ($2::date + INTERVAL '1 day') AT TIME ZONE 'Asia/Jakarta' AS end_ts
+),
+filtered_transactions AS (
+    SELECT 
+        t.id, 
+        t.total_amount, 
+        (t.created_at AT TIME ZONE 'Asia/Jakarta')::date AS day,
+        t.created_at
+    FROM transactions t, date_range dr
+    WHERE t.created_at >= dr.start_ts AND t.created_at < dr.end_ts
+),
+summary AS (
+    SELECT 
+        COALESCE(SUM(total_amount), 0) AS total_revenue,
+        COUNT(id) AS total_transactions,
+        COALESCE(SUM(total_amount) / NULLIF(COUNT(id), 0), 0) AS avg_order_value
+    FROM filtered_transactions
+),
+top_products AS (
+    SELECT jsonb_agg(jsonb_build_object('product_name', product_name, 'quantity', total_qty)) as list
+    FROM (
+        SELECT td.product_name, SUM(td.quantity) as total_qty
+        FROM transaction_details td
+        JOIN filtered_transactions ft ON td.transaction_id = ft.id
+        GROUP BY 1 ORDER BY 2 DESC LIMIT 5
+    ) AS sub
+),
+daily_trend AS (
+    SELECT jsonb_agg(jsonb_build_object('date', day, 'daily_revenue', daily_revenue)) as trend
+    FROM (
+        SELECT day, SUM(total_amount) AS daily_revenue
+        FROM filtered_transactions
+        GROUP BY 1 ORDER BY 1 ASC
+    ) AS sub
+),
+total_qty AS (
+    SELECT COALESCE(SUM(td.quantity), 0) as total_items_sold
+    FROM transaction_details td
+    JOIN filtered_transactions ft ON td.transaction_id = ft.id
+)
+SELECT 
+    s.total_revenue, 
+    s.total_transactions, 
+    s.avg_order_value, 
+    tq.total_items_sold,
+    COALESCE(tp.list, '[]'::jsonb) as top_5_products,
+    COALESCE(dt.trend, '[]'::jsonb) as daily_revenue_trend
+FROM summary s, top_products tp, daily_trend dt, total_qty tq;
+	`
+	var r models.FullReport
+	var topProductsJSON, dailyTrendJSON []byte
+	err := repo.db.QueryRow(query, startDate, endDate).Scan(
+		&r.Summary.TotalRevenue,
+		&r.Summary.TotalTransactions,
+		&r.Summary.AOV,
+		&r.Summary.TotalItemsSold,
+		&topProductsJSON,
+		&dailyTrendJSON,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(topProductsJSON, &r.Top5Products); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(dailyTrendJSON, &r.DailyRevenueTrend); err != nil {
+		return nil, err
+	}
 	return &r, nil
 }

--- a/services/report_service.go
+++ b/services/report_service.go
@@ -16,3 +16,7 @@ func NewReportService(repo *repositories.ReportRepository) *ReportService {
 func (s *ReportService) GetDailyReport() (*models.DailyReport, error) {
 	return s.repo.GetDailyReport()
 }
+
+func (s *ReportService) GetReport(startDate, endDate string) (*models.FullReport, error) {
+	return s.repo.GetReport(startDate, endDate)
+}


### PR DESCRIPTION
Added a new analytics endpoint to fetch comprehensive business performance data.

### **Changes**
- `GET /api/report` with `start_date` and `end_date` query parameters.
- Defaults to the last 30 days if no date parameters are provided.
- Implemented PostgreSQL CTEs and JSON aggregation to fetch `Summary`,` Top 5 Products`, and `Daily Trends` in one trip.
- Integrated Asia/Jakarta timezone handling at the database level.
- Added Bruno collection file (`.bru`) for easier API testing.

Closes #11 